### PR TITLE
Change config names

### DIFF
--- a/templates/vector.toml.j2
+++ b/templates/vector.toml.j2
@@ -2,9 +2,9 @@
 data_dir = "/var/lib/vector"
 
 {% set loop_helper = {
-    "sources": (sources | default({})),
-    "transforms": (transforms | default({})),
-    "sinks": (sinks | default({}))
+    "sources": (vecotr_sources_config | default({})),
+    "transforms": (vector_transforms_config | default({})),
+    "sinks": (vector_sinks_config | default({}))
 } %}
 
 {% for name, cat in loop_helper.items() | sort(attribute='0') %}

--- a/templates/vector.toml.j2
+++ b/templates/vector.toml.j2
@@ -2,7 +2,7 @@
 data_dir = "/var/lib/vector"
 
 {% set loop_helper = {
-    "sources": (vecotr_sources_config | default({})),
+    "sources": (vector_sources_config | default({})),
     "transforms": (vector_transforms_config | default({})),
     "sinks": (vector_sinks_config | default({}))
 } %}

--- a/templates/vector.yaml.j2
+++ b/templates/vector.yaml.j2
@@ -1,9 +1,9 @@
 {{ vector_general_config | default("") }}
 sources:
-  {{ sources | to_nice_yaml | indent(2) }}
-{% if transforms is defined %}
+  {{ vector_sources_config | to_nice_yaml | indent(2) }}
+{% if vector_transforms_config is defined %}
 transforms:
-  {{ transforms | to_nice_yaml | indent(2) }}
+  {{ vector_transforms_config | to_nice_yaml | indent(2) }}
 {% endif %}
 sinks:
-  {{ sinks | to_nice_yaml | indent(2) }}
+  {{ vector_sinks_config | to_nice_yaml | indent(2) }}


### PR DESCRIPTION
The generally named variables for configuring vector have a high probability of colliding. We prefer more scoped and descriptive variable names.