### PR TITLE
fixing ownership issue

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,13 @@
     line: "VECTOR_CONFIG={{ vector_config_file }}"
     state: present
 
+- name: Ensure /var/lib/vector/ is owned by vector user and group
+  file:
+    path: /var/lib/vector/
+    owner: vector
+    group: vector
+    recurse: no
+
 - name: Start and enable Vector service
   service:
     name: vector


### PR DESCRIPTION
noticing that most services are failing to restart on dreampress servers. they may, or may not, start on initial setup, but restarting the service for whatever reason fails with exit code 1.

/var/lib/vector/ is owned by 996:996, which isn't correct. this makes sure vector:vector owns the directory so the service can load.